### PR TITLE
Update univariate_kalman_filter.jl

### DIFF
--- a/src/filters/univariate_kalman_filter.jl
+++ b/src/filters/univariate_kalman_filter.jl
@@ -195,9 +195,14 @@ function update_P!(
 end
 
 function update_llk!(kalman_state::UnivariateKalmanState{Fl}) where Fl
-    kalman_state.llk -= (
-        HALF_LOG_2_PI + (log(kalman_state.F) + kalman_state.v^2 / kalman_state.F) / 2
-    )
+    try
+        kalman_state.llk -= (
+            HALF_LOG_2_PI + (log(kalman_state.F) + kalman_state.v^2 / kalman_state.F) / 2
+        )
+    catch err
+        println(err)
+        println(kalman_state.F) # log gets negative value
+    end
     return kalman_state
 end
 


### PR DESCRIPTION
The auto_arima function is getting an error in the choose_best_model function (line 739) because it couldn't find 'candidate_models.' This error occurs in the update_llk function, where the logarithm gets negative values during optimization.